### PR TITLE
:sparkles: Ajout d'un attribut `token` associés à la relation entre un joueur et une partie

### DIFF
--- a/.github/comusparty_export.sql
+++ b/.github/comusparty_export.sql
@@ -264,7 +264,7 @@ CREATE TABLE `cp_played`
 (
     `game_uuid`   varchar(63) NOT NULL,
     `player_uuid` varchar(63) NOT NULL,
-    `token`       varchar(16) NOT NULL
+    `token`       varchar(16) NULL DEFAULT NULL
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
   COLLATE = utf8mb4_general_ci;

--- a/.github/comusparty_export.sql
+++ b/.github/comusparty_export.sql
@@ -263,7 +263,8 @@ VALUES (1, 'mod_uuid1', NULL, 'uuid2', 'Inappropriate behavior', 30, 'muted', NU
 CREATE TABLE `cp_played`
 (
     `game_uuid`   varchar(63) NOT NULL,
-    `player_uuid` varchar(63) NOT NULL
+    `player_uuid` varchar(63) NOT NULL,
+    `token`       varchar(16) NOT NULL
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
   COLLATE = utf8mb4_general_ci;


### PR DESCRIPTION
Ce nouvel attribut permet de pouvoir gérer une session de jeu d'un joueur afin que les serveurs de jeu puissent l'identifier.