### PR TITLE
Correction du chat de partie en direct

### DIFF
--- a/public/assets/js/game.js
+++ b/public/assets/js/game.js
@@ -71,14 +71,14 @@ function sendChatMessage() {
     const content = messageInput.value;
     const username = document.getElementById('headerUsername').textContent;
 
-    conn.send(JSON.stringify({
+    chatConnection.send(JSON.stringify({
         author: username,
         content: content,
         game: gameCode,
     }));
 
     messageInput.value = '';
-    chatConnection.send(messageItem.textContent);
+    chatConnection.send(content);
 }
 
 function receiveChatMessage(message) {
@@ -118,7 +118,7 @@ function closeModal() {
 }
 
 // WebSocket
-const chatConnection = new WebSocket('ws://sockets.comus-party.com/chat/' + gameCode);
+const chatConnection = new WebSocket('ws://localhost:8315/chat/' + gameCode);
 chatConnection.onopen = function (e) {
     console.log("Connexion établie avec CHAT_SOCKET !");
 };

--- a/public/assets/js/game.js
+++ b/public/assets/js/game.js
@@ -82,7 +82,6 @@ function sendChatMessage() {
 
 function receiveChatMessage(message) {
     message = JSON.parse(message);
-    console.log(message);
     const messages = document.getElementById('chatContent');
     const messageItem = document.createElement('p');
     messageItem.classList.add("flex");

--- a/public/assets/js/game.js
+++ b/public/assets/js/game.js
@@ -77,8 +77,7 @@ function sendChatMessage() {
         game: gameCode
     }));
 
-    messageInput.value = ''
-    receiveChatMessage(JSON.stringify({author: username, content: content}));
+    messageInput.value = '';
 }
 
 function receiveChatMessage(message) {

--- a/public/assets/js/game.js
+++ b/public/assets/js/game.js
@@ -74,15 +74,16 @@ function sendChatMessage() {
     chatConnection.send(JSON.stringify({
         author: username,
         content: content,
-        game: gameCode,
+        game: gameCode
     }));
 
-    messageInput.value = '';
-    chatConnection.send(content);
+    messageInput.value = ''
+    receiveChatMessage(JSON.stringify({author: username, content: content}));
 }
 
 function receiveChatMessage(message) {
     message = JSON.parse(message);
+    console.log(message);
     const messages = document.getElementById('chatContent');
     const messageItem = document.createElement('p');
     messageItem.classList.add("flex");


### PR DESCRIPTION
- correction de l'adresse du serveur de web-socket (passage en localhost)
- correction de l'appel de variable qui était incorrect (conn => chatConnection)
- affichage sur l'écran de l'auteur de son propre message (appel de la méthode recieveChatMessage())

Il y a une chose que je ne comprends pas : l'information en passe pas par le serveur de websocket, la boucle à la ligne 62 du fichier `Chat.php` n'est pas exécutée, il semble que le message entier passe direct d'un client à tous les autres.

En principe, le serveur renvoi à tous les clients ce JSON :
``` 
$player->send(json_encode([
          "author" => $author,
          "content" => $content
]));
```
            
Mais les joueurs reçoivent directement celui-ci, qui est envoyé par le client :
```
chatConnection.send(JSON.stringify({
        author: username,
        content: content,
        game: gameCode
}));
```

J'ai essayé d'ajouter des nouveaux couples de clés-valeurs pour essayer, et effectivement on dirait que ça ne passe pas par le serveur